### PR TITLE
Add missing CHECK comments on UncheckedAccounts

### DIFF
--- a/programs/conf_hide/src/lib.rs
+++ b/programs/conf_hide/src/lib.rs
@@ -694,6 +694,7 @@ pub struct InitOrderBookCompDef<'info> {
     pub payer: Signer<'info>,
     #[account(mut, address = derive_mxe_pda!())]
     pub mxe_account: Box<Account<'info, MXEAccount>>,
+    /// CHECK: Validated by Arcium program
     #[account(mut)]
     pub comp_def_account: UncheckedAccount<'info>,
     pub arcium_program: Program<'info, Arcium>,
@@ -707,6 +708,7 @@ pub struct InitSubmitOrderCompDef<'info> {
     pub payer: Signer<'info>,
     #[account(mut, address = derive_mxe_pda!())]
     pub mxe_account: Box<Account<'info, MXEAccount>>,
+    /// CHECK: Validated by Arcium program
     #[account(mut)]
     pub comp_def_account: UncheckedAccount<'info>,
     pub arcium_program: Program<'info, Arcium>,
@@ -720,6 +722,7 @@ pub struct InitCancelOrderCompDef<'info> {
     pub payer: Signer<'info>,
     #[account(mut, address = derive_mxe_pda!())]
     pub mxe_account: Box<Account<'info, MXEAccount>>,
+    /// CHECK: Validated by Arcium program
     #[account(mut)]
     pub comp_def_account: UncheckedAccount<'info>,
     pub arcium_program: Program<'info, Arcium>,
@@ -733,6 +736,7 @@ pub struct InitMatchOrdersCompDef<'info> {
     pub payer: Signer<'info>,
     #[account(mut, address = derive_mxe_pda!())]
     pub mxe_account: Box<Account<'info, MXEAccount>>,
+    /// CHECK: Validated by Arcium program
     #[account(mut)]
     pub comp_def_account: UncheckedAccount<'info>,
     pub arcium_program: Program<'info, Arcium>,


### PR DESCRIPTION
Program build was failing because of this, which then messed up more things down the line. Adding this fixes all these issues.